### PR TITLE
Fix parse issues

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,6 @@
 name: Linters and tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 

--- a/src/degiro.py
+++ b/src/degiro.py
@@ -99,6 +99,12 @@ def parse_single_row(row: List[str], dates: Sequence[datetime.date], date_index:
     elif description == "DEGIRO Geldmarktfondsen Compensatie":
         cash[date_index:] += mutation * currency_modifier
 
+    elif description == "Fondsuitkering":
+        cash[date_index:] += mutation * currency_modifier
+
+    elif description == "Rente":
+        cash[date_index:] += mutation * currency_modifier
+
     elif "Conversie geldmarktfonds" in description:
         pass  # Nothing to do?
 

--- a/src/degiro.py
+++ b/src/degiro.py
@@ -54,7 +54,7 @@ def parse_single_row(row: List[str], dates: Sequence[datetime.date], date_index:
     elif description.split(" ")[0] in ("Koop", "Verkoop"):
         buy_or_sell = "sell" if description.split(" ")[0] == "Verkoop" else "buy"
         multiplier = -1 if buy_or_sell == "sell" else 1
-        num_shares = int(description.split(" ")[1])
+        num_shares = int(description.split(" ")[1].replace(".", ""))
         is_etf = any([etf_subname.lower() in name.lower() for etf_subname in SUBSTRINGS_IN_ETF])
         this_share_value, _ = market.get_data_by_isin(isin, dates, is_etf=is_etf)
         if this_share_value is None:  # no historical prices available for this stock/etf

--- a/src/degiro.py
+++ b/src/degiro.py
@@ -162,9 +162,11 @@ def parse_account(csv_data: List[List[str]], dates: List[datetime.date]) -> Tupl
     total_account = shares_value + cash
     absolutes = {"nominal account (without profit/loss)": invested,
                  "cash in DeGiro account": cash,
-                 "total account value": total_account}
+                 "total account value": total_account,
+                 "profit/loss": total_account - invested}
 
     # Set the relative metrics
     performance = np.divide(total_account, invested, out=np.zeros_like(invested), where=invested != 0)
+
     relatives = {"account performance":  performance}
     return absolutes, relatives

--- a/src/degiro.py
+++ b/src/degiro.py
@@ -38,7 +38,7 @@ def parse_single_row(row: List[str], dates: Sequence[datetime.date], date_index:
 
     # ----- Cash in and out -----
 
-    if description in ("iDEAL storting",):
+    if description in ("iDEAL storting", "Storting"):
         if bank_cash[date_index] > mutation:
             bank_cash[date_index:] -= mutation
         else:

--- a/src/degiro.py
+++ b/src/degiro.py
@@ -162,8 +162,7 @@ def parse_account(csv_data: List[List[str]], dates: List[datetime.date]) -> Tupl
     total_account = shares_value + cash
     absolutes = {"nominal account (without profit/loss)": invested,
                  "cash in DeGiro account": cash,
-                 "total account value": total_account,
-                 "profit/loss": total_account - invested}
+                 "total account value": total_account}
 
     # Set the relative metrics
     performance = np.divide(total_account, invested, out=np.zeros_like(invested), where=invested != 0)

--- a/src/degiro.py
+++ b/src/degiro.py
@@ -59,8 +59,8 @@ def parse_single_row(row: List[str], dates: Sequence[datetime.date], date_index:
         this_share_value, _ = market.get_data_by_isin(isin, dates, is_etf=is_etf)
         if this_share_value is None:  # no historical prices available for this stock/etf
             this_share_value = np.zeros(shape=len(dates)) + (-mutation / num_shares)
-        this_share_value_eur = this_share_value[date_index] * currency_modifier
-        print(f"[DGPC] {date}: {buy_or_sell:4s} {num_shares:4d} @ {this_share_value_eur:8.2f} EUR of {name}")
+
+        print(f"[DGPC] {date}: {buy_or_sell:4s} {num_shares:4d} @ {this_share_value[date_index]:8.2f} EUR of {name}")
 
         shares_value[date_index:] += multiplier * num_shares * this_share_value[date_index:]
         cash[date_index:] += mutation * currency_modifier

--- a/src/main.py
+++ b/src/main.py
@@ -118,10 +118,6 @@ def dgpc(input_file: Path, output_png: Path, output_csv: Path, end_date: datetim
     print(f"[DGPC] Storing results also as CSV '{output_csv}'")
     store_csv(dates, absolute_data, relative_data, output_csv)
 
-    # Print balances on end date
-    print(f"[DGPC] Total account value at { dates[-1] }: €{absolute_data['total account value'][-1]:.2f}")
-    print(f"[DGPC] (Un)realized gain at { dates[-1] }: €{absolute_data['profit/loss'][-1]:.2f}")
-
 
 def main() -> None:
     """Main entry point of DGPC from the command-line."""

--- a/src/main.py
+++ b/src/main.py
@@ -77,6 +77,7 @@ def dgpc(input_file: Path, output_png: Path, output_csv: Path, end_date: datetim
     # Preliminaries: read the CSV file and set the date range structure
     print(f"[DGPC] Reading DeGiro data from '{input_file}'")
     csv_data, first_date = degiro.read_account(input_file)
+
     num_days = (end_date - first_date).days
     dates = [first_date + datetime.timedelta(days=days) for days in range(0, num_days)]
 
@@ -116,6 +117,10 @@ def dgpc(input_file: Path, output_png: Path, output_csv: Path, end_date: datetim
     # Storing data also as CSV for reference
     print(f"[DGPC] Storing results also as CSV '{output_csv}'")
     store_csv(dates, absolute_data, relative_data, output_csv)
+
+    # Print balances on end date
+    print(f"[DGPC] Total account value at { dates[-1] }: €{absolute_data['total account value'][-1]:.2f}")
+    print(f"[DGPC] (Un)realized gain at { dates[-1] }: €{absolute_data['profit/loss'][-1]:.2f}")
 
 
 def main() -> None:


### PR DESCRIPTION
Fixes these issues:
- Parse error when the number of shares is >1000, because a number separator is used in the data (ex: 1.234).
- "Storting" was not recognized as a deposit (only iDEAL deposits were).
- Display only: Share buy/sell in foreign currency printed a double-converted price.